### PR TITLE
Bugfix Deadlock when getting the lock

### DIFF
--- a/fetchtool/abstract_fetch.py
+++ b/fetchtool/abstract_fetch.py
@@ -343,7 +343,7 @@ class AbstractDataFetcher(ABC):
             self.create_empty_file(download_file)
 
         lock_file = download_file + ".lock"
-        # Lock for 1 minute, timeout after 10 minutes to avoid deadlocking the code if it can get the lock
+        # Lock for 1 minute, timeout after 10 minutes to avoid deadlocking the code if it can't get the lock
         with Lock(lock_file, lifetime=60, default_timeout=60 * 10):
             existing_rows = set(self.read_download_data(project_accession))
             existing_rows = existing_rows.union(set(new_download_rows))


### PR DESCRIPTION
This is to prevent a deadlock if the code can't get the lock file.

Example:
ERROR 2024/11/14 03:55:11 PM - lifetime has expired, breaking
ERROR 2024/11/14 03:55:11 PM - lockfile exists but isn't safe to break: /hps/nobackup/rdf/metagenomics/service-team/production/automated_jobs/ERP1432/ERP143252/download.lock

If this happens the process hangs there indefinitely. With the timeout the code will fail and exit with a Timeout error at least.

I think we need to review this lock files... we can probably remove them (or at least add unit tests to check the code is doing what we expect)